### PR TITLE
Remove references to "DomePlatform"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## - unreleased
+### Fixed
+- In power component, show only Certification, OnBoarding and ProductOffering functions
 
 ### Removed
 - In home wallet section, verifier link and introductory text

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "in2-issuer-ui",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/shared/components/power/power/power.component.html
+++ b/src/app/shared/components/power/power/power.component.html
@@ -32,8 +32,8 @@
 
 <div *ngIf="viewMode === 'create'">
   <div *ngFor="let option of addedOptions; let i = index" class="option-container">
+    <p>{{ option.tmf_function }}</p>
     <ng-container *ngIf="option.tmf_function === 'Certification'">
-      <p>{{ option.tmf_function }}</p>
       <mat-slide-toggle [(ngModel)]="option.upload" name="upload-{{ i }}" [disabled]="isDisabled">
         {{ "power.upload" | translate }}
       </mat-slide-toggle>
@@ -42,7 +42,6 @@
       </mat-slide-toggle>
     </ng-container>
     <ng-container *ngIf="option.tmf_function === 'ProductOffering'">
-      <p>{{ option.tmf_function }}</p>
       <mat-slide-toggle [(ngModel)]="option.create" name="create-{{ i }}" [disabled]="isDisabled">
         {{ "power.create" | translate }}
       </mat-slide-toggle>
@@ -54,7 +53,6 @@
       </mat-slide-toggle>
     </ng-container>
     <ng-container *ngIf="option.tmf_function === 'Onboarding'">
-      <p>{{ option.tmf_function }}</p>
       <mat-slide-toggle [(ngModel)]="option.execute" name="execute-{{ i }}" [disabled]="isDisabled">
         {{ "power.execute" | translate }}
       </mat-slide-toggle>
@@ -65,7 +63,6 @@
 <div *ngIf="viewMode === 'detail'">
   <div *ngFor="let option of power; let i = index" class="option-container">
     <ng-container *ngIf="option.tmf_function === 'Certification'">
-      <p>{{ option.tmf_function }}</p>
       <mat-slide-toggle [(ngModel)]="option.upload" name="upload-{{ i }}" [disabled]="isDisabled">
         {{ "power.upload" | translate }}
       </mat-slide-toggle>
@@ -74,7 +71,6 @@
       </mat-slide-toggle>
     </ng-container>
     <ng-container *ngIf="option.tmf_function === 'ProductOffering'">
-      <p>{{ option.tmf_function }}</p>
       <mat-slide-toggle [(ngModel)]="option.create" name="create-{{ i }}" disabled>
         {{ "power.create" | translate }}
       </mat-slide-toggle>
@@ -86,7 +82,6 @@
       </mat-slide-toggle>
     </ng-container>
     <ng-container *ngIf="option.tmf_function === 'Onboarding'">
-      <p>{{ option.tmf_function }}</p>
       <mat-slide-toggle [(ngModel)]="option.execute" name="execute-{{ i }}" disabled>
         {{ "power.execute" | translate }}
       </mat-slide-toggle>

--- a/src/app/shared/components/power/power/power.component.html
+++ b/src/app/shared/components/power/power/power.component.html
@@ -32,8 +32,8 @@
 
 <div *ngIf="viewMode === 'create'">
   <div *ngFor="let option of addedOptions; let i = index" class="option-container">
-    <p>{{ option.tmf_function }}</p>
     <ng-container *ngIf="option.tmf_function === 'Certification'">
+      <p>{{ option.tmf_function }}</p>
       <mat-slide-toggle [(ngModel)]="option.upload" name="upload-{{ i }}" [disabled]="isDisabled">
         {{ "power.upload" | translate }}
       </mat-slide-toggle>
@@ -42,6 +42,7 @@
       </mat-slide-toggle>
     </ng-container>
     <ng-container *ngIf="option.tmf_function === 'ProductOffering'">
+      <p>{{ option.tmf_function }}</p>
       <mat-slide-toggle [(ngModel)]="option.create" name="create-{{ i }}" [disabled]="isDisabled">
         {{ "power.create" | translate }}
       </mat-slide-toggle>
@@ -53,6 +54,7 @@
       </mat-slide-toggle>
     </ng-container>
     <ng-container *ngIf="option.tmf_function === 'Onboarding'">
+      <p>{{ option.tmf_function }}</p>
       <mat-slide-toggle [(ngModel)]="option.execute" name="execute-{{ i }}" [disabled]="isDisabled">
         {{ "power.execute" | translate }}
       </mat-slide-toggle>
@@ -62,8 +64,8 @@
 
 <div *ngIf="viewMode === 'detail'">
   <div *ngFor="let option of power; let i = index" class="option-container">
-    <p>{{ option.tmf_function }}</p>
     <ng-container *ngIf="option.tmf_function === 'Certification'">
+      <p>{{ option.tmf_function }}</p>
       <mat-slide-toggle [(ngModel)]="option.upload" name="upload-{{ i }}" [disabled]="isDisabled">
         {{ "power.upload" | translate }}
       </mat-slide-toggle>
@@ -72,6 +74,7 @@
       </mat-slide-toggle>
     </ng-container>
     <ng-container *ngIf="option.tmf_function === 'ProductOffering'">
+      <p>{{ option.tmf_function }}</p>
       <mat-slide-toggle [(ngModel)]="option.create" name="create-{{ i }}" disabled>
         {{ "power.create" | translate }}
       </mat-slide-toggle>
@@ -83,6 +86,7 @@
       </mat-slide-toggle>
     </ng-container>
     <ng-container *ngIf="option.tmf_function === 'Onboarding'">
+      <p>{{ option.tmf_function }}</p>
       <mat-slide-toggle [(ngModel)]="option.execute" name="execute-{{ i }}" disabled>
         {{ "power.execute" | translate }}
       </mat-slide-toggle>

--- a/src/app/shared/components/power/power/power.component.html
+++ b/src/app/shared/components/power/power/power.component.html
@@ -61,7 +61,8 @@
 </div>
 
 <div *ngIf="viewMode === 'detail'">
-  <div *ngFor="let option of power; let i = index" class="option-container">
+  <div *ngFor="let option of _power; let i = index" class="option-container">
+    <p>{{ option.tmf_function }}</p>
     <ng-container *ngIf="option.tmf_function === 'Certification'">
       <mat-slide-toggle [(ngModel)]="option.upload" name="upload-{{ i }}" [disabled]="isDisabled">
         {{ "power.upload" | translate }}

--- a/src/app/shared/components/power/power/power.component.html
+++ b/src/app/shared/components/power/power/power.component.html
@@ -61,7 +61,7 @@
 </div>
 
 <div *ngIf="viewMode === 'detail'">
-  <div *ngFor="let option of _power; let i = index" class="option-container">
+  <div *ngFor="let option of power; let i = index" class="option-container">
     <p>{{ option.tmf_function }}</p>
     <ng-container *ngIf="option.tmf_function === 'Certification'">
       <mat-slide-toggle [(ngModel)]="option.upload" name="upload-{{ i }}" [disabled]="isDisabled">

--- a/src/app/shared/components/power/power/power.component.spec.ts
+++ b/src/app/shared/components/power/power/power.component.spec.ts
@@ -41,19 +41,17 @@ describe('PowerComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should filter addedOptions on init', () => {
-    component.addedOptions = [
+  it('should filter power on init', () => {
+    component.power = [
       { tmf_function: 'Onboarding' },
       { tmf_function: 'DomePlatform' },
       { tmf_function: 'Certification' },
       { tmf_function: 'ProductOffering' },
       { tmf_function: 'random' }
     ] as any;
-  
-    component.ngOnInit();
 
-    expect(component.addedOptions.length).toBe(3);
-    expect(component.addedOptions).toEqual([
+    expect(component._power.length).toBe(3);
+    expect(component._power).toEqual([
       { tmf_function: 'Onboarding' },
       { tmf_function: 'Certification' },
       { tmf_function: 'ProductOffering' }

--- a/src/app/shared/components/power/power/power.component.spec.ts
+++ b/src/app/shared/components/power/power/power.component.spec.ts
@@ -41,6 +41,25 @@ describe('PowerComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('should filter addedOptions on init', () => {
+    component.addedOptions = [
+      { tmf_function: 'Onboarding' },
+      { tmf_function: 'DomePlatform' },
+      { tmf_function: 'Certification' },
+      { tmf_function: 'ProductOffering' },
+      { tmf_function: 'random' }
+    ] as any;
+  
+    component.ngOnInit();
+
+    expect(component.addedOptions.length).toBe(3);
+    expect(component.addedOptions).toEqual([
+      { tmf_function: 'Onboarding' },
+      { tmf_function: 'Certification' },
+      { tmf_function: 'ProductOffering' }
+    ]);
+  });
+
   it('should not add an option if isDisabled is true', () => {
     component.isDisabled = true;
     component.selectedOption = 'TestOption';

--- a/src/app/shared/components/power/power/power.component.ts
+++ b/src/app/shared/components/power/power/power.component.ts
@@ -21,7 +21,16 @@ export interface TempPower {
 export class PowerComponent implements OnInit{
   @Input() public isDisabled: boolean = false;
   @Input() public viewMode: 'create' | 'detail' = 'create';
-  @Input() public power: TempPower[] = [];
+  public _power: TempPower[] = [];
+  public get power(){
+    return this._power;
+  }
+  @Input() 
+  public set power(value:TempPower[]){
+    this._power = value.filter(option =>
+      ['Onboarding', 'ProductOffering', 'Certification'].includes(option.tmf_function)
+    );
+  }
   @Input() public addedOptions: TempPower[] = [];
   @Output() public addedOptionsChange = new EventEmitter<TempPower[]>();
   @Output() public selectedOptionChange = new EventEmitter<string>();

--- a/src/app/shared/components/power/power/power.component.ts
+++ b/src/app/shared/components/power/power/power.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
 
 export interface TempPower {
   tmf_action: string | string[];
@@ -18,7 +18,7 @@ export interface TempPower {
   templateUrl: './power.component.html',
   styleUrls: ['./power.component.scss']
 })
-export class PowerComponent {
+export class PowerComponent implements OnInit{
   @Input() public isDisabled: boolean = false;
   @Input() public viewMode: 'create' | 'detail' = 'create';
   @Input() public power: TempPower[] = [];
@@ -30,6 +30,12 @@ export class PowerComponent {
   public selectedOption: string = '';
   public popupMessage: string = '';
   public isPopupVisible: boolean = false;
+
+  public ngOnInit(): void {
+    this.addedOptions = this.addedOptions.filter(option =>
+      ['Onboarding', 'ProductOffering', 'Certification'].includes(option.tmf_function)
+    );
+  }
 
   public addOption(): void {
     if (this.isDisabled) return;

--- a/src/app/shared/components/power/power/power.component.ts
+++ b/src/app/shared/components/power/power/power.component.ts
@@ -21,7 +21,7 @@ export interface TempPower {
 export class PowerComponent{
   @Input() public isDisabled: boolean = false;
   @Input() public viewMode: 'create' | 'detail' = 'create';
-  public _power: TempPower[] = [];
+  private _power: TempPower[] = [];
   public get power(){
     return this._power;
   }

--- a/src/app/shared/components/power/power/power.component.ts
+++ b/src/app/shared/components/power/power/power.component.ts
@@ -18,7 +18,7 @@ export interface TempPower {
   templateUrl: './power.component.html',
   styleUrls: ['./power.component.scss']
 })
-export class PowerComponent implements OnInit{
+export class PowerComponent{
   @Input() public isDisabled: boolean = false;
   @Input() public viewMode: 'create' | 'detail' = 'create';
   public _power: TempPower[] = [];
@@ -39,12 +39,6 @@ export class PowerComponent implements OnInit{
   public selectedOption: string = '';
   public popupMessage: string = '';
   public isPopupVisible: boolean = false;
-
-  public ngOnInit(): void {
-    this.addedOptions = this.addedOptions.filter(option =>
-      ['Onboarding', 'ProductOffering', 'Certification'].includes(option.tmf_function)
-    );
-  }
 
   public addOption(): void {
     if (this.isDisabled) return;


### PR DESCRIPTION
Hide references to DomePlatform. Some old credentials coming from backend contain tmf_function with value "DomePlatform", which was displayed in credentials view. It has been solved filtering the powers in power component.