### PR TITLE
fix(dialog-wrapper service): don't execute action if cancel is selecte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.3](https://github.com/in2workspace/in2-issuer-ui/releases/tag/v1.6.3)
+### Fixed
+- In credential issuance form, after clicking on remove power icon, don't remove power if user clicks "Cancel"
+
+### Changed
+- In credential issuance form, remove back arrow
+- In details page, make back arrow bigger
+- In credential offer Step 1, center 
+
 ## [1.6.2](https://github.com/in2workspace/in2-issuer-ui/releases/tag/v1.6.2)
 ### Fixed
 - In credential offer stepper, when clicking refresh button, close popup and don't leave while it's refreshing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "in2-issuer-ui",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/features/credential-offer/credential-offer-steps/credential-offer-onboarding/credential-offer-onboarding.component.scss
+++ b/src/app/features/credential-offer/credential-offer-steps/credential-offer-onboarding/credential-offer-onboarding.component.scss
@@ -1,1 +1,5 @@
 @import '../credential-offer-step/credential-offer-step.component.scss';
+
+.guide-text{
+    text-align: center;
+}

--- a/src/app/shared/components/dialog/dialog-wrapper/dialog-wrapper.service.spec.ts
+++ b/src/app/shared/components/dialog/dialog-wrapper/dialog-wrapper.service.spec.ts
@@ -68,7 +68,7 @@ describe('DialogWrapperService', () => {
       status: 'default'
     };
     const callback = jest.fn(() => of('success'));
-    const afterClosedSubject = new Subject<void>();
+    const afterClosedSubject = new Subject<boolean>();
     const dialogRefMock = {
       afterClosed: jest.fn(() => afterClosedSubject.asObservable()),
       close: jest.fn(),
@@ -78,7 +78,7 @@ describe('DialogWrapperService', () => {
 
     service.openDialogWithCallback(dialogData, callback);
 
-    afterClosedSubject.next();
+    afterClosedSubject.next(true);
     afterClosedSubject.complete();
 
     expect(matDialogMock.open).toHaveBeenCalledWith(DialogComponent, {
@@ -99,7 +99,7 @@ describe('DialogWrapperService', () => {
       loadingData: { title: 'Loading', message: 'Loading Message' },
     };
     const callback = jest.fn(() => of('success'));
-    const afterConfirmSubject = new Subject<void>();
+    const afterConfirmSubject = new Subject<true>();
     const dialogRefMock = {
       componentInstance: {
         afterConfirm$: jest.fn(() => afterConfirmSubject.asObservable()),
@@ -112,7 +112,7 @@ describe('DialogWrapperService', () => {
 
     service.openDialogWithCallback(dialogData, callback);
 
-    afterConfirmSubject.next();
+    afterConfirmSubject.next(true);
     afterConfirmSubject.complete();
 
     expect(matDialogMock.open).toHaveBeenCalledWith(DialogComponent, {
@@ -134,7 +134,7 @@ describe('DialogWrapperService', () => {
       status: 'default'
     };
     const callback = jest.fn(() => throwError(() => new Error('Callback Error')));
-    const afterClosedSubject = new Subject<void>();
+    const afterClosedSubject = new Subject<boolean>();
     const dialogRefMock = {
       afterClosed: jest.fn(() => afterClosedSubject.asObservable()),
       close: jest.fn(),
@@ -144,7 +144,7 @@ describe('DialogWrapperService', () => {
 
     service.openDialogWithCallback(dialogData, callback);
 
-    afterClosedSubject.next();
+    afterClosedSubject.next(true);
     afterClosedSubject.complete();
 
     expect(matDialogMock.open).toHaveBeenCalledWith(DialogComponent, {

--- a/src/app/shared/components/dialog/dialog-wrapper/dialog-wrapper.service.spec.ts
+++ b/src/app/shared/components/dialog/dialog-wrapper/dialog-wrapper.service.spec.ts
@@ -222,4 +222,25 @@ describe('DialogWrapperService', () => {
 
     expect(cancelCallback).toHaveBeenCalled();
   });
+
+  it('should execute callback on true condition', () => {
+    const callback = jest.fn(() => of('executed'));
+    const result = service['executeCallbackOnCondition'](callback, true);
+  
+    return result.toPromise().then((value) => {
+      expect(callback).toHaveBeenCalled();
+      expect(value).toBe('executed');
+    });
+  });
+  
+  it('should return EMPTY on false condition', () => {
+    const callback = jest.fn(() => of('executed'));
+    const result = service['executeCallbackOnCondition'](callback, false);
+  
+    return result.toPromise().then((value) => {
+      expect(callback).not.toHaveBeenCalled();
+      expect(value).toBeUndefined(); // EMPTY no emet cap valor
+    });
+  });
+  
 });

--- a/src/app/shared/components/dialog/dialog-wrapper/dialog-wrapper.service.ts
+++ b/src/app/shared/components/dialog/dialog-wrapper/dialog-wrapper.service.ts
@@ -1,7 +1,7 @@
 import { DestroyRef, inject, Injectable } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { DialogComponent, DialogData } from '../dialog.component';
-import { filter, Observable, switchMap, take, tap } from 'rxjs';
+import { EMPTY, filter, Observable, switchMap, take, tap } from 'rxjs';
 import { LoaderService } from 'src/app/core/services/loader.service';
 
 @Injectable({
@@ -78,7 +78,14 @@ export class DialogWrapperService {
     confirmObservable
       .pipe(
         take(1),
-        switchMap(callback)
+        switchMap((confirmation:boolean)=>{
+          if(confirmation){
+            return callback()
+          }else{
+            return EMPTY;
+          }
+        
+        })
       )
       .subscribe({
         next: () => { 

--- a/src/app/shared/components/dialog/dialog-wrapper/dialog-wrapper.service.ts
+++ b/src/app/shared/components/dialog/dialog-wrapper/dialog-wrapper.service.ts
@@ -4,6 +4,8 @@ import { DialogComponent, DialogData } from '../dialog.component';
 import { EMPTY, filter, Observable, switchMap, take, tap } from 'rxjs';
 import { LoaderService } from 'src/app/core/services/loader.service';
 
+export type observableCallback = () => Observable<any>;
+
 @Injectable({
   providedIn: 'root'
 })
@@ -48,7 +50,7 @@ export class DialogWrapperService {
   //It is important not to cut error flow (tipically with catchError) in callback passed as argument, since then the
   //dialog will be closed in the next callback of openDialogWithCallback. The server interceptor reuses the already opened dialog to display its error message (see openErrorInfoDialog),
   //which will be immediately closed by the next callback of openDialogWithCallback if the error flow is cut.
-  public openDialogWithCallback(dialogData: DialogData, callback:() => Observable<any>, cancelCallback?: () => Observable<any>, disableClose?:'DISABLE_CLOSE'): void{
+  public openDialogWithCallback(dialogData: DialogData, callback: observableCallback, cancelCallback?: () => Observable<any>, disableClose?:'DISABLE_CLOSE'): void{
     const dialogRef = this.dialog.open(
       DialogComponent, 
       { 
@@ -79,12 +81,7 @@ export class DialogWrapperService {
       .pipe(
         take(1),
         switchMap((confirmation:boolean)=>{
-          if(confirmation){
-            return callback()
-          }else{
-            return EMPTY;
-          }
-        
+          return this.executeCallbackOnCondition(callback, confirmation);
         })
       )
       .subscribe({
@@ -120,5 +117,13 @@ export class DialogWrapperService {
       }
 
   }
+
+  private executeCallbackOnCondition(callback: observableCallback, condition: boolean): Observable<any> {
+    if(condition){
+      return callback();
+    }
+     return EMPTY;
+  }
+
 
 }

--- a/src/app/shared/components/dialog/dialog.component.ts
+++ b/src/app/shared/components/dialog/dialog.component.ts
@@ -55,7 +55,7 @@ export class DialogComponent {
   public statusColor = 'primary';
   public currentStatus: DialogStatus | undefined = undefined;
 
-  private readonly confirmSubj$ = new Subject<boolean>();
+  private readonly confirmSubj$ = new Subject<true>();
 
   public constructor(){
     this.dialogRef.addPanelClass('dialog-custom');

--- a/src/app/shared/components/form-credential/form-credential.component.html
+++ b/src/app/shared/components/form-credential/form-credential.component.html
@@ -1,7 +1,9 @@
 <app-navbar></app-navbar>
-<button type="button" [routerLink]="['/organization/credentials']" class="back-button" aria-label="Back to credentials">
-  <mat-icon class="back-icon" fontIcon="arrow_back"></mat-icon>
-</button>
+@if(viewMode ===  'detail'){
+  <button type="button" [routerLink]="['/organization/credentials']" class="back-button" aria-label="Back to credentials">
+    <mat-icon class="back-icon" fontIcon="arrow_back"></mat-icon>
+  </button>
+}
 <div class="page-container">
     <h1>{{ title }}</h1>
     <div class="credential-container">

--- a/src/app/shared/components/form-credential/form-credential.component.scss
+++ b/src/app/shared/components/form-credential/form-credential.component.scss
@@ -23,7 +23,10 @@
   transition: transform 0.2s ease-in-out;
 
   .back-icon{
-    font-size: 20px;
+    display: block;
+    width: 40px;
+    height: 40px;
+    font-size: 40px;
     fill: black;
   }
 }
@@ -62,7 +65,7 @@ div.mat-mdc-form-field-text-prefix:has(span.prefix-container){
 }
 
 .page-container{
-  padding: 16px 16px 24px 16px;
+  padding: 50px 16px 24px 16px;
 }
 
 .credential-container {
@@ -144,9 +147,9 @@ div.mat-mdc-form-field-text-prefix:has(span.prefix-container){
 // MEDIA QUERIES
 @media(width > 768px){
   .page-container{
-    max-width:1000px;
-    margin-inline:auto;
-    padding: 20px 20px 30px 20px;
+    max-width: 1000px;
+    margin-inline: auto;
+    padding: 50px 20px 30px 20px;
   }
 
   .credential-container {
@@ -197,8 +200,15 @@ div.mat-mdc-form-field-text-prefix:has(span.prefix-container){
 }
 
 @media(width > 1150px){
+
   .back-button{
-    top: 113px;
+    top: 139px;
     left: 23px;
+  }
+
+  .back-icon{
+    width: 40px;
+    height: 40px;
+    font-size: 40px;
   }
 }


### PR DESCRIPTION
## [1.6.3](https://github.com/in2workspace/in2-issuer-ui/releases/tag/v1.6.3)
### Fixed
- In credential issuance form, after clicking on remove power icon, don't remove power if user clicks "Cancel"

### Changed
- In credential issuance form, remove back arrow
- In details page, make back arrow bigger
- In credential offer Step 1, center 